### PR TITLE
Use the correct query param name for exchange rates api

### DIFF
--- a/src/public.rs
+++ b/src/public.rs
@@ -55,7 +55,7 @@ impl Public {
     /// https://developers.coinbase.com/api/v2#exchange-rates
     ///
     pub async fn exchange_rates(&self, currency: &str) -> Result<ExchangeRates> {
-        let uri = UriTemplate::new("/v2/exchange-rates{?query*}")
+        let uri = UriTemplate::new("/v2/exchange-rates{?currency*}")
             .set("currency", currency)
             .build();
         self.get(&uri).await


### PR DESCRIPTION
Coinbase returns USD by default if it's not included. In this case, it was always returning exchange rates for USD